### PR TITLE
docs: fix tutorial accuracy for RA onboarding

### DIFF
--- a/docs/user/tutorials/contributing-entries.md
+++ b/docs/user/tutorials/contributing-entries.md
@@ -39,6 +39,13 @@ Select **term** when prompted, then fill in:
 | Alternatives | `边际费用` | Other valid translations (comma-separated) |
 | Source | `quantecon/supply-demand` | Where you found this term (optional) |
 
+:::{note}
+After you enter the English text, the CLI checks whether an identical entry
+already exists in the dataset (case-insensitive). If a duplicate is found,
+you'll see the existing entry and be asked "Add anyway?" — the default is
+**No** to prevent accidental duplicates.
+:::
+
 After filling in the fields, you'll see a preview:
 
 ```

--- a/docs/user/tutorials/first-session.md
+++ b/docs/user/tutorials/first-session.md
@@ -28,7 +28,7 @@ uv run qebench stats
 ```
 
 You should see the coverage panel and domain table. The dataset is pre-seeded
-with 300+ economics terms — enough to start practicing immediately.
+with 314 economics and math terms — enough to start practicing immediately.
 
 ## Step 3: Start a Short Session
 
@@ -45,15 +45,20 @@ Your GitHub username is detected automatically from `gh auth`.
 For each entry, you'll see a panel like:
 
 ```
-╭──────── TERM ────────╮
-│                       │
-│  inflation            │
-│                       │
-│  term-001 · economics │
-│           · basic     │
-╰───────────────────────╯
+╭──────────────── TERM ────────────────╮
+│                                      │
+│  inflation                           │
+│                                      │
+│  Context: "The rate of inflation     │
+│  determines the real interest rate." │
+│                                      │
+│  term-001 · economics · basic        │
+╰──────────────────────────────────────╯
 ? Your translation (中文):
 ```
+
+Terms with context sentences (populated by `qebench update`) show an example
+from a QuantEcon lecture to help you choose the right translation.
 
 Type your Chinese translation and press Enter.
 
@@ -140,7 +145,7 @@ This pulls the latest changes, commits your results, and pushes — all in one c
 
 Once pushed, the CI workflow rebuilds the dashboard with your activity and XP.
 
-## Step 8: Try Different Filters
+## Step 9: Try Different Filters
 
 Focus on a specific domain:
 

--- a/docs/user/tutorials/judging-translations.md
+++ b/docs/user/tutorials/judging-translations.md
@@ -71,9 +71,26 @@ Two translations appear side by side:
 The labels A and B are randomized — you don't know which model produced
 which translation until the reveal.
 
-## Step 5: Score Each Translation
+## Step 5: Pick the Winner
 
-Rate **Translation A** on two dimensions:
+After comparing both translations, pick the overall winner:
+
+```
+Which is better overall?
+  A is better
+❯ B is better
+  Tie — equally good
+  Neither — both are poor
+```
+
+If both are equally good, pick **Tie**. If both are poor and neither is
+acceptable, pick **Neither**. Don't overthink it — go with your first
+instinct after reading both.
+
+## Step 6: Score Each Translation
+
+If you picked A or B as the winner, you'll be asked to rate each translation
+on two dimensions. (For **Tie** and **Neither**, scoring is skipped.)
 
 ```
 Rate Translation A:
@@ -91,20 +108,6 @@ Rate Translation B:
 
 **Accuracy** means how faithfully the translation captures the meaning.
 **Fluency** means how natural and readable the Chinese is.
-
-## Step 6: Pick the Winner
-
-```
-Which is better overall?
-  A is better
-❯ B is better
-  Tie — equally good
-  Neither — both are poor
-```
-
-If both are equally good, pick **Tie**. If both are poor and neither is
-acceptable, pick **Neither**. Don't overthink it — go with your first
-instinct after reading both.
 
 ## Step 7: See the Reveal
 


### PR DESCRIPTION
## Summary

Audited all 5 tutorials against current source code to ensure accuracy for RA onboarding. Fixed 5 issues across 3 files.

## Changes

### `first-session.md`
- **Seed count**: "300+" → "314" (matches actual dataset)
- **Panel mock**: Added context sentence display — `qebench update` populates these, and the translate command renders them when available
- **Step numbering**: Fixed duplicate "Step 8" → renumbered to "Step 9"

### `judging-translations.md`
- **Flow reorder**: Swapped Steps 5 & 6 — tutorial now shows **winner selection first**, then scoring, matching the actual code flow in `commands/judge.py`
- **Tie/Neither note**: Added that scoring is skipped for Tie and Neither verdicts

### `contributing-entries.md`
- **Duplicate detection**: Added `:::{note}` about the new v0.3.1 duplicate detection feature (case-insensitive check after entering English text)

## Not changed
- `running-llm-benchmarks.md` — already updated in PR #18
- `updating-datasets.md` — accurate as-is

## Testing
- All 218 tests passing
- Verified CLI commands from tutorials: `stats`, `run --dry-run`, `doctor`
