### PR TITLE
fix: judge auto-ties caused by prompt template collisions

### DIFF
--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -38,10 +38,14 @@ WINNER_CHOICES = [
 
 
 def _load_model_outputs() -> dict[str, dict[str, str]]:
-    """Load all model outputs, keyed by model name then entry_id.
+    """Load all model outputs, keyed by model:prompt label then entry_id.
+
+    Keys use the format ``model:prompt_template`` (e.g.
+    ``claude-sonnet-4-6:academic``) when a ``prompt_template`` field is
+    present, or plain ``model`` as a fallback for older records.
 
     Returns:
-        {model_name: {entry_id: translated_text, ...}, ...}
+        {label: {entry_id: translated_text, ...}, ...}
     """
     outputs: dict[str, dict[str, str]] = {}
     if not MODEL_OUTPUTS_DIR.exists():

--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -55,10 +55,13 @@ def _load_model_outputs() -> dict[str, dict[str, str]]:
                     continue
                 record = json.loads(line)
                 model = record.get("model", "unknown")
+                prompt = record.get("prompt_template", "")
+                # Key by model:prompt so different prompts are distinct
+                label = f"{model}:{prompt}" if prompt else model
                 entry_id = record.get("entry_id", "")
                 translated = record.get("translated_text", "")
                 if entry_id and translated:
-                    outputs.setdefault(model, {})[entry_id] = translated
+                    outputs.setdefault(label, {})[entry_id] = translated
 
     return outputs
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -65,6 +65,21 @@ class TestLoadModelOutputs:
         assert "claude" in outputs
         assert "gpt-4o" in outputs
 
+    def test_prompt_template_creates_distinct_keys(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.commands.judge.MODEL_OUTPUTS_DIR", tmp_path)
+        records = [
+            {"model": "claude", "prompt_template": "default", "entry_id": "term-001", "translated_text": "通胀A"},
+            {"model": "claude", "prompt_template": "academic", "entry_id": "term-001", "translated_text": "通胀B"},
+        ]
+        path = tmp_path / "run-1.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+        outputs = _load_model_outputs()
+        assert "claude:default" in outputs
+        assert "claude:academic" in outputs
+        assert outputs["claude:default"]["term-001"] == "通胀A"
+        assert outputs["claude:academic"]["term-001"] == "通胀B"
+
 
 class TestBuildMatchups:
     def test_no_model_outputs(self) -> None:


### PR DESCRIPTION
## Problem

`qebench judge` shows "Both identical — auto-tie" for most rounds, giving users no opportunity to actually judge.

**Root cause**: `_load_model_outputs()` keys by the `model` field alone. When the same model is run with different prompts (e.g. `claude-sonnet-4-6` with `default` and `academic`), the second run overwrites the first. This reduced 4 model-prompt runs down to just 2 models, and 77% of their term translations are identical.

## Fix

Key model outputs by `model:prompt_template` (e.g. `claude-sonnet-4-6:academic`) instead of just `model`. This gives 4 distinct model-prompt combinations for judging. Records without `prompt_template` (backward compat) still key by model name alone.

## Testing
- 219 tests passing (218 + 1 new test for prompt keying)
- Verified: 4 distinct models now visible in `_load_model_outputs()`
- Identical pair rates drop because more diverse pairings are available
