### PR TITLE
feat: consensus rating when all models agree + 0-5 scoring scale

### DIFF
--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -104,7 +104,7 @@ def _build_matchups(
         if len(available) >= 2:
             # Try to find a pair with different translations
             pairs = list(itertools.combinations(available, 2))
-            diff_pairs = [(a, b) for a, b in pairs if a[1] != b[1]]
+            diff_pairs = [(a, b) for a, b in pairs if a[1].strip() != b[1].strip()]
             if diff_pairs:
                 pair = list(random.choice(diff_pairs))
             else:
@@ -283,9 +283,11 @@ def judge(
             console.print(_render_source(entry, i))
 
             consensus_text = text_a.strip()
+            is_ref_match = label_a == "human-reference" or label_b == "human-reference"
+            header = "Model matches reference:" if is_ref_match else "All models agree:"
             console.print(
                 Panel(
-                    f"All models agree:\n\n[bold]{consensus_text}[/bold]",
+                    f"{header}\n\n[bold]{consensus_text}[/bold]",
                     title="[bold green]Consensus[/bold green]",
                     border_style="green",
                     padding=(1, 2),
@@ -311,10 +313,14 @@ def judge(
                     "Suggest a better translation (optional):",
                 ).ask() or ""
 
+            consensus_models = [
+                lbl for lbl in (label_a, label_b) if lbl != "human-reference"
+            ]
+
             record_consensus(
                 username=username,
                 entry_id=entry.id,
-                models=[label_a, label_b],
+                models=consensus_models,
                 translation=consensus_text,
                 accuracy=c_acc,
                 fluency=c_flu,

--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -7,6 +7,7 @@ Results update Elo ratings and earn XP.
 
 from __future__ import annotations
 
+import itertools
 import json
 import random
 from datetime import UTC, datetime
@@ -19,7 +20,7 @@ from rich.table import Table
 from qebench import __version__
 from qebench.models import Paragraph, Sentence, Term
 from qebench.scoring.glossary import glossary_compliance, reference_overlap
-from qebench.scoring.judgments import record_judgment, update_model_elos
+from qebench.scoring.judgments import record_consensus, record_judgment, update_model_elos
 from qebench.scoring.xp import award_xp, load_xp
 from qebench.utils.dataset import RESULTS_DIR, load_all, load_terms
 from qebench.utils.display import console
@@ -27,7 +28,7 @@ from qebench.utils.github import get_github_username
 
 MODEL_OUTPUTS_DIR = RESULTS_DIR / "model-outputs"
 
-SCORE_CHOICES = [questionary.Choice(str(i), value=i) for i in range(1, 11)]
+SCORE_CHOICES = [questionary.Choice(str(i), value=i) for i in range(6)]
 
 WINNER_CHOICES = [
     questionary.Choice("A is better", value="a"),
@@ -80,7 +81,8 @@ def _build_matchups(
     Labels are the real model names (hidden from user during judging).
 
     Strategy:
-    - If 2+ models have output for an entry → pair two models
+    - If 2+ models have output for an entry → prefer a pair with different
+      translations so judges have something meaningful to compare.
     - If 1 model has output → pair model vs. reference ("human")
     - If 0 model outputs → skip (need at least one model output to judge)
     """
@@ -100,8 +102,13 @@ def _build_matchups(
             continue
 
         if len(available) >= 2:
-            # Pair two random models
-            pair = random.sample(available, 2)
+            # Try to find a pair with different translations
+            pairs = list(itertools.combinations(available, 2))
+            diff_pairs = [(a, b) for a, b in pairs if a[1] != b[1]]
+            if diff_pairs:
+                pair = list(random.choice(diff_pairs))
+            else:
+                pair = random.sample(available, 2)
         else:
             # Pair single model vs. reference
             pair = [available[0], ("human-reference", entry.zh)]
@@ -269,34 +276,49 @@ def judge(
         label_a = matchup["label_a"]
         label_b = matchup["label_b"]
 
-        # Skip identical translations — auto-record a tie (#9)
+        # Identical translations — ask human to rate the consensus
         if text_a.strip() == text_b.strip():
             skipped_identical += 1
+            console.print(f"\n[dim]── Round {i}/{len(matchups)} ──[/dim]")
+            console.print(_render_source(entry, i))
+
+            consensus_text = text_a.strip()
             console.print(
-                f"\n[dim]── Round {i}/{len(matchups)} ──[/dim]"
-            )
-            console.print(
-                f"[dim]Both identical ({text_a.strip()[:30]}…) — auto-tie, skipping.[/dim]"
-                if len(text_a.strip()) > 30
-                else f"[dim]Both identical ({text_a.strip()}) — auto-tie, skipping.[/dim]"
+                Panel(
+                    f"All models agree:\n\n[bold]{consensus_text}[/bold]",
+                    title="[bold green]Consensus[/bold green]",
+                    border_style="green",
+                    padding=(1, 2),
+                )
             )
 
-            is_reference = label_a == "human-reference" or label_b == "human-reference"
-            if is_reference:
-                elo_a = elo_b = 0.0
-            else:
-                elo_a, elo_b = update_model_elos(label_a, label_b, "tie")
+            c_acc = questionary.rawselect(
+                "Accuracy (0-5):", choices=SCORE_CHOICES,
+            ).ask()
+            if c_acc is None:
+                console.print("[yellow]Session ended early.[/yellow]")
+                break
+            c_flu = questionary.rawselect(
+                "Fluency (0-5):", choices=SCORE_CHOICES,
+            ).ask()
+            if c_flu is None:
+                console.print("[yellow]Session ended early.[/yellow]")
+                break
 
-            record_judgment(
+            suggestion = ""
+            if c_acc <= 2 or c_flu <= 2:
+                suggestion = questionary.text(
+                    "Suggest a better translation (optional):",
+                ).ask() or ""
+
+            record_consensus(
                 username=username,
                 entry_id=entry.id,
-                model_a=label_a,
-                model_b=label_b,
-                winner="tie",
-                score_a_accuracy=None,
-                score_a_fluency=None,
-                score_b_accuracy=None,
-                score_b_fluency=None,
+                models=[label_a, label_b],
+                translation=consensus_text,
+                accuracy=c_acc,
+                fluency=c_flu,
+                suggestion=suggestion,
                 timestamp=datetime.now(UTC).isoformat(),
                 cli_version=__version__,
             )
@@ -322,22 +344,22 @@ def judge(
         else:
             # Collect scores for A
             console.print("\n[bold yellow]Rate Translation A:[/bold yellow]")
-            acc_a = questionary.rawselect("  Accuracy (1-10):", choices=SCORE_CHOICES).ask()
+            acc_a = questionary.rawselect("  Accuracy (0-5):", choices=SCORE_CHOICES).ask()
             if acc_a is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
-            flu_a = questionary.rawselect("  Fluency (1-10):", choices=SCORE_CHOICES).ask()
+            flu_a = questionary.rawselect("  Fluency (0-5):", choices=SCORE_CHOICES).ask()
             if flu_a is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
 
             # Collect scores for B
             console.print("[bold magenta]Rate Translation B:[/bold magenta]")
-            acc_b = questionary.rawselect("  Accuracy (1-10):", choices=SCORE_CHOICES).ask()
+            acc_b = questionary.rawselect("  Accuracy (0-5):", choices=SCORE_CHOICES).ask()
             if acc_b is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
-            flu_b = questionary.rawselect("  Fluency (1-10):", choices=SCORE_CHOICES).ask()
+            flu_b = questionary.rawselect("  Fluency (0-5):", choices=SCORE_CHOICES).ask()
             if flu_b is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
@@ -386,7 +408,7 @@ def judge(
         summary.add_column("Value", style="bold")
         summary.add_row("Rounds completed:", f"{completed}/{len(matchups)}")
         if skipped_identical:
-            summary.add_row("Identical (auto-tie):", str(skipped_identical))
+            summary.add_row("Consensus rated:", str(skipped_identical))
         summary.add_row("XP earned:", f"+{xp_earned}")
         summary.add_row("Total XP:", str(total_xp))
 

--- a/src/qebench/scoring/judgments.py
+++ b/src/qebench/scoring/judgments.py
@@ -67,6 +67,37 @@ def record_judgment(
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
+def record_consensus(
+    *,
+    username: str,
+    entry_id: str,
+    models: list[str],
+    translation: str,
+    accuracy: int,
+    fluency: int,
+    suggestion: str,
+    timestamp: str,
+    cli_version: str,
+) -> None:
+    """Append a consensus-rating record to the user's JSONL file."""
+    JUDGMENTS_DIR.mkdir(parents=True, exist_ok=True)
+    path = JUDGMENTS_DIR / f"{username}.jsonl"
+
+    record = {
+        "type": "consensus",
+        "entry_id": entry_id,
+        "models": models,
+        "translation": translation,
+        "accuracy": accuracy,
+        "fluency": fluency,
+        "suggestion": suggestion,
+        "timestamp": timestamp,
+        "cli_version": cli_version,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
 def update_model_elos(model_a: str, model_b: str, winner: str) -> tuple[float, float]:
     """Update Elo ratings for two models after a judgment.
 

--- a/src/qebench/scoring/judgments.py
+++ b/src/qebench/scoring/judgments.py
@@ -75,11 +75,15 @@ def record_consensus(
     translation: str,
     accuracy: int,
     fluency: int,
-    suggestion: str,
+    suggestion: str = "",
     timestamp: str,
     cli_version: str,
 ) -> None:
     """Append a consensus-rating record to the user's JSONL file."""
+    if not 0 <= accuracy <= 5:
+        raise ValueError("accuracy must be between 0 and 5")
+    if not 0 <= fluency <= 5:
+        raise ValueError("fluency must be between 0 and 5")
     JUDGMENTS_DIR.mkdir(parents=True, exist_ok=True)
     path = JUDGMENTS_DIR / f"{username}.jsonl"
 

--- a/tests/test_judgments.py
+++ b/tests/test_judgments.py
@@ -168,3 +168,31 @@ class TestRecordConsensus:
         )
         records = [json.loads(ln) for ln in (tmp_path / "testuser.jsonl").read_text().splitlines()]
         assert records[0]["suggestion"] == "\u4ee3\u4ef7\u51fd\u6570"
+
+    def test_invalid_accuracy_raises(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        with pytest.raises(ValueError, match="accuracy"):
+            record_consensus(
+                username="testuser",
+                entry_id="term-001",
+                models=["claude:default"],
+                translation="通货膨胀",
+                accuracy=6,
+                fluency=3,
+                timestamp="2026-04-07T12:00:00Z",
+                cli_version="0.3.2",
+            )
+
+    def test_invalid_fluency_raises(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        with pytest.raises(ValueError, match="fluency"):
+            record_consensus(
+                username="testuser",
+                entry_id="term-001",
+                models=["claude:default"],
+                translation="通货膨胀",
+                accuracy=3,
+                fluency=-1,
+                timestamp="2026-04-07T12:00:00Z",
+                cli_version="0.3.2",
+            )

--- a/tests/test_judgments.py
+++ b/tests/test_judgments.py
@@ -8,6 +8,7 @@ import pytest
 
 from qebench.scoring.judgments import (
     load_elo_ratings,
+    record_consensus,
     record_judgment,
     save_elo_ratings,
     update_model_elos,
@@ -76,10 +77,10 @@ class TestRecordJudgment:
             model_a="claude",
             model_b="gpt-4o",
             winner="a",
-            score_a_accuracy=8,
-            score_a_fluency=9,
-            score_b_accuracy=7,
-            score_b_fluency=6,
+            score_a_accuracy=4,
+            score_a_fluency=5,
+            score_b_accuracy=3,
+            score_b_fluency=3,
             timestamp="2026-04-02T12:00:00Z",
             cli_version="0.3.0",
         )
@@ -89,7 +90,7 @@ class TestRecordJudgment:
         assert len(records) == 1
         assert records[0]["entry_id"] == "term-001"
         assert records[0]["winner"] == "a"
-        assert records[0]["score_a"]["accuracy"] == 8
+        assert records[0]["score_a"]["accuracy"] == 4
 
     def test_appends_multiple(self, tmp_path, monkeypatch) -> None:
         monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
@@ -100,10 +101,10 @@ class TestRecordJudgment:
                 model_a="claude",
                 model_b="gpt-4o",
                 winner="b",
-                score_a_accuracy=5,
-                score_a_fluency=5,
-                score_b_accuracy=8,
-                score_b_fluency=8,
+                score_a_accuracy=3,
+                score_a_fluency=3,
+                score_b_accuracy=4,
+                score_b_fluency=5,
                 timestamp="2026-04-02T12:00:00Z",
                 cli_version="0.3.0",
             )
@@ -120,11 +121,50 @@ class TestRecordJudgment:
             model_a="claude",
             model_b="gpt-4o",
             winner="tie",
-            score_a_accuracy=7,
-            score_a_fluency=7,
-            score_b_accuracy=7,
-            score_b_fluency=7,
+            score_a_accuracy=3,
+            score_a_fluency=3,
+            score_b_accuracy=3,
+            score_b_fluency=3,
             timestamp="2026-04-02T12:00:00Z",
             cli_version="0.3.0",
         )
         assert (out_dir / "testuser.jsonl").exists()
+
+
+class TestRecordConsensus:
+    def test_saves_consensus(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        record_consensus(
+            username="testuser",
+            entry_id="term-001",
+            models=["claude:default", "claude:academic"],
+            translation="\u901a\u8d27\u81a8\u80c0",
+            accuracy=5,
+            fluency=4,
+            suggestion="",
+            timestamp="2026-04-07T12:00:00Z",
+            cli_version="0.3.2",
+        )
+        path = tmp_path / "testuser.jsonl"
+        assert path.exists()
+        records = [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+        assert len(records) == 1
+        assert records[0]["type"] == "consensus"
+        assert records[0]["accuracy"] == 5
+        assert records[0]["models"] == ["claude:default", "claude:academic"]
+
+    def test_with_suggestion(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        record_consensus(
+            username="testuser",
+            entry_id="term-008",
+            models=["claude:default"],
+            translation="\u6210\u672c\u51fd\u6570",
+            accuracy=1,
+            fluency=3,
+            suggestion="\u4ee3\u4ef7\u51fd\u6570",
+            timestamp="2026-04-07T12:00:00Z",
+            cli_version="0.3.2",
+        )
+        records = [json.loads(ln) for ln in (tmp_path / "testuser.jsonl").read_text().splitlines()]
+        assert records[0]["suggestion"] == "\u4ee3\u4ef7\u51fd\u6570"


### PR DESCRIPTION
## Problem

When all models produce identical translations (68% of terms), `judge` auto-tied silently — giving RAs no opportunity to assess anything. Rounds felt wasted.

## Solution

### Consensus rating flow
When translations are identical, show the source (with context) and the agreed translation, then ask the human to rate:
- **Accuracy** (0-5): How faithfully it captures the meaning
- **Fluency** (0-5): How natural the Chinese reads

If either score is <= 2, an optional text field asks for a better translation suggestion.

### 0-5 scoring scale
Changed from 1-10 to 0-5 for both head-to-head and consensus ratings. Simpler and more intuitive.

### Prefer non-identical pairs
`_build_matchups` now uses `itertools.combinations` to find pairs with different translations first. Only falls back to random pairing when all translations for an entry are identical.

### Data format
Consensus ratings saved in the same JSONL with `"type": "consensus"`:
```json
{"type": "consensus", "entry_id": "term-001", "models": ["claude-sonnet-4-6:default", "claude-sonnet-4-6:academic"], "translation": "通货膨胀", "accuracy": 5, "fluency": 5, "suggestion": "", ...}
```

## Testing
- 221 tests passing (219 + 2 new for `record_consensus`)
- Head-to-head scores updated to 0-5 range in tests
