### PR TITLE
fix: judge UX improvements

### DIFF
--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -28,13 +28,13 @@ from qebench.utils.github import get_github_username
 
 MODEL_OUTPUTS_DIR = RESULTS_DIR / "model-outputs"
 
-SCORE_CHOICES = [questionary.Choice(str(i), value=i) for i in range(6)]
+SCORE_CHOICES = [questionary.Choice(str(i), value=i, shortcut_key=str(i)) for i in range(6)]
 
 WINNER_CHOICES = [
-    questionary.Choice("A is better", value="a"),
-    questionary.Choice("B is better", value="b"),
-    questionary.Choice("Tie — equally good", value="tie"),
-    questionary.Choice("Neither — both are poor", value="neither"),
+    questionary.Choice("A is better", value="a", shortcut_key="a"),
+    questionary.Choice("B is better", value="b", shortcut_key="b"),
+    questionary.Choice("Tie — equally good", value="tie", shortcut_key="t"),
+    questionary.Choice("Neither — both are poor", value="neither", shortcut_key="n"),
 ]
 
 
@@ -125,15 +125,37 @@ def _build_matchups(
         })
 
     random.shuffle(matchups)
-    return matchups
+
+    # Separate into disagreements and consensus, then interleave so the
+    # user always gets a mix of both (disagreements are more interesting
+    # but consensus ratings are still valuable).
+    diff_matchups = [m for m in matchups if m["translation_a"].strip() != m["translation_b"].strip()]
+    same_matchups = [m for m in matchups if m["translation_a"].strip() == m["translation_b"].strip()]
+
+    interleaved: list[dict] = []
+    di, si = 0, 0
+    while di < len(diff_matchups) or si < len(same_matchups):
+        # Alternate: diff, same, diff, same, ...
+        if di < len(diff_matchups):
+            interleaved.append(diff_matchups[di])
+            di += 1
+        if si < len(same_matchups):
+            interleaved.append(same_matchups[si])
+            si += 1
+
+    return interleaved
 
 
 def _render_source(entry: Term | Sentence | Paragraph, round_num: int) -> Panel:
     """Render the English source text panel."""
     entry_type = entry.id.split("-")[0].upper()
     meta = f"[dim]{entry.id} · {entry.domain} · {entry.difficulty.value}[/dim]"
+    body = f"[bold]{entry.en}[/bold]\n\n{meta}"
+    if isinstance(entry, Term) and entry.contexts:
+        ctx = entry.contexts[0].text
+        body += f"\n\n[dim italic]Context: {ctx}[/dim italic]"
     return Panel(
-        f"{entry.en}\n\n{meta}",
+        body,
         title=f"[bold cyan]Judge[/bold cyan]  [dim](Round {round_num})[/dim]  [dim]{entry_type}[/dim]",
         border_style="cyan",
         padding=(1, 2),
@@ -294,14 +316,14 @@ def judge(
                 )
             )
 
-            c_acc = questionary.rawselect(
-                "Accuracy (0-5):", choices=SCORE_CHOICES,
+            c_acc = questionary.select(
+                "Accuracy (0-5):", choices=SCORE_CHOICES, use_shortcuts=True,
             ).ask()
             if c_acc is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
-            c_flu = questionary.rawselect(
-                "Fluency (0-5):", choices=SCORE_CHOICES,
+            c_flu = questionary.select(
+                "Fluency (0-5):", choices=SCORE_CHOICES, use_shortcuts=True,
             ).ask()
             if c_flu is None:
                 console.print("[yellow]Session ended early.[/yellow]")
@@ -336,36 +358,42 @@ def judge(
         console.print(_render_translations(text_a, text_b))
 
         # Ask winner FIRST (#9)
-        winner_answer = questionary.rawselect(
+        winner_answer = questionary.select(
             "Which is better overall?",
             choices=WINNER_CHOICES,
+            use_shortcuts=True,
         ).ask()
         if winner_answer is None:
             console.print("[yellow]Session ended early.[/yellow]")
             break
 
         # For ties and neither, skip detailed scoring (#9)
+        suggestion = ""
         if winner_answer in ("tie", "neither"):
             acc_a = acc_b = flu_a = flu_b = None
+            if winner_answer == "neither":
+                suggestion = questionary.text(
+                    "Suggest a better translation (optional):",
+                ).ask() or ""
         else:
             # Collect scores for A
             console.print("\n[bold yellow]Rate Translation A:[/bold yellow]")
-            acc_a = questionary.rawselect("  Accuracy (0-5):", choices=SCORE_CHOICES).ask()
+            acc_a = questionary.select("  Accuracy (0-5):", choices=SCORE_CHOICES, use_shortcuts=True).ask()
             if acc_a is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
-            flu_a = questionary.rawselect("  Fluency (0-5):", choices=SCORE_CHOICES).ask()
+            flu_a = questionary.select("  Fluency (0-5):", choices=SCORE_CHOICES, use_shortcuts=True).ask()
             if flu_a is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
 
             # Collect scores for B
             console.print("[bold magenta]Rate Translation B:[/bold magenta]")
-            acc_b = questionary.rawselect("  Accuracy (0-5):", choices=SCORE_CHOICES).ask()
+            acc_b = questionary.select("  Accuracy (0-5):", choices=SCORE_CHOICES, use_shortcuts=True).ask()
             if acc_b is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
-            flu_b = questionary.rawselect("  Fluency (0-5):", choices=SCORE_CHOICES).ask()
+            flu_b = questionary.select("  Fluency (0-5):", choices=SCORE_CHOICES, use_shortcuts=True).ask()
             if flu_b is None:
                 console.print("[yellow]Session ended early.[/yellow]")
                 break
@@ -388,6 +416,7 @@ def judge(
             score_a_fluency=flu_a,
             score_b_accuracy=acc_b,
             score_b_fluency=flu_b,
+            suggestion=suggestion,
             timestamp=datetime.now(UTC).isoformat(),
             cli_version=__version__,
         )

--- a/src/qebench/commands/judge.py
+++ b/src/qebench/commands/judge.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 import questionary
 from rich.columns import Columns
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 
@@ -150,9 +151,9 @@ def _render_source(entry: Term | Sentence | Paragraph, round_num: int) -> Panel:
     """Render the English source text panel."""
     entry_type = entry.id.split("-")[0].upper()
     meta = f"[dim]{entry.id} · {entry.domain} · {entry.difficulty.value}[/dim]"
-    body = f"[bold]{entry.en}[/bold]\n\n{meta}"
+    body = f"[bold]{escape(entry.en)}[/bold]\n\n{meta}"
     if isinstance(entry, Term) and entry.contexts:
-        ctx = entry.contexts[0].text
+        ctx = escape(entry.contexts[0].text)
         body += f"\n\n[dim italic]Context: {ctx}[/dim italic]"
     return Panel(
         body,

--- a/src/qebench/scoring/judgments.py
+++ b/src/qebench/scoring/judgments.py
@@ -46,6 +46,7 @@ def record_judgment(
     score_a_fluency: int | None,
     score_b_accuracy: int | None,
     score_b_fluency: int | None,
+    suggestion: str = "",
     timestamp: str,
     cli_version: str,
 ) -> None:
@@ -63,6 +64,8 @@ def record_judgment(
         "timestamp": timestamp,
         "cli_version": cli_version,
     }
+    if suggestion:
+        record["suggestion"] = suggestion
     with open(path, "a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
 

--- a/tests/test_judgments.py
+++ b/tests/test_judgments.py
@@ -130,6 +130,43 @@ class TestRecordJudgment:
         )
         assert (out_dir / "testuser.jsonl").exists()
 
+    def test_suggestion_stored(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        record_judgment(
+            username="testuser",
+            entry_id="term-001",
+            model_a="claude",
+            model_b="gpt-4o",
+            winner="neither",
+            score_a_accuracy=None,
+            score_a_fluency=None,
+            score_b_accuracy=None,
+            score_b_fluency=None,
+            suggestion="更好的翻译",
+            timestamp="2026-04-02T12:00:00Z",
+            cli_version="0.3.2",
+        )
+        records = [json.loads(ln) for ln in (tmp_path / "testuser.jsonl").read_text().splitlines()]
+        assert records[0]["suggestion"] == "更好的翻译"
+
+    def test_empty_suggestion_omitted(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("qebench.scoring.judgments.JUDGMENTS_DIR", tmp_path)
+        record_judgment(
+            username="testuser",
+            entry_id="term-001",
+            model_a="claude",
+            model_b="gpt-4o",
+            winner="tie",
+            score_a_accuracy=None,
+            score_a_fluency=None,
+            score_b_accuracy=None,
+            score_b_fluency=None,
+            timestamp="2026-04-02T12:00:00Z",
+            cli_version="0.3.2",
+        )
+        records = [json.loads(ln) for ln in (tmp_path / "testuser.jsonl").read_text().splitlines()]
+        assert "suggestion" not in records[0]
+
 
 class TestRecordConsensus:
     def test_saves_consensus(self, tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Judge UX improvements based on hands-on testing:

**Context display**
- Show the first context sentence from `Term.contexts` in the source panel so judges have disambiguation info

**Keyboard navigation**
- Switch all score/winner prompts from `rawselect` to `select` with `use_shortcuts=True` — now supports both arrow keys and keyboard shortcuts
- Score shortcuts match actual values (press 5 for score 5, not 1-indexed offset)
- Winner shortcuts: `a`/`b`/`t`/`n` for quick selection

**Suggestion on "Neither"**
- When judge picks "Neither — both are poor", prompt for an optional better translation (same pattern as consensus low-score flow)
- Store suggestion in judgment JSONL record

**Balanced matchup ordering**
- Interleave disagreement and consensus matchups so a 5-round session gets ~3 disagreements + ~2 consensus instead of mostly consensus
