### PR TITLE
fix: resolve merge conflict in Cindy6308.jsonl and harden export readers

### DIFF
--- a/results/translations/Cindy6308.jsonl
+++ b/results/translations/Cindy6308.jsonl
@@ -1,11 +1,9 @@
-<<<<<<< Updated upstream
 {"entry_id": "term-209", "attempt": "三角形式", "reference": "三角形式", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-11T15:20:35.972521+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-208", "attempt": "强连通的", "reference": "强连通的", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-11T15:27:57.926783+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-230", "attempt": "最优策略", "reference": "最优策略", "confidence": 4, "similarity": 1.0, "timestamp": "2026-05-11T15:29:01.113719+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-280", "attempt": "高斯核", "reference": "高斯核", "confidence": 4, "similarity": 1.0, "timestamp": "2026-05-11T15:32:47.489393+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-031", "attempt": "贴现因子", "reference": "贴现因子", "confidence": 4, "similarity": 1.0, "timestamp": "2026-05-11T15:35:03.702795+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-050", "attempt": "政府预算约束", "reference": "政府预算约束", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-11T15:35:44.045894+00:00", "cli_version": "0.5.0"}
-=======
 {"entry_id": "term-079", "attempt": "随机生产率", "reference": "随机生产率", "confidence": 3, "similarity": 1.0, "timestamp": "2026-05-08T15:09:05.840031+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-295", "attempt": "西尔弗曼法则", "reference": "西尔弗曼法则", "confidence": 4, "similarity": 1.0, "timestamp": "2026-05-08T15:26:12.938352+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-099", "attempt": "通货膨胀指数化债券", "reference": "通胀指数化债券", "confidence": 4, "similarity": 0.7778, "timestamp": "2026-05-08T15:35:55.850858+00:00", "cli_version": "0.5.0", "diff_reason": "abbreviation", "notes": "The reference is the abbreviation of my translation."}
@@ -16,7 +14,6 @@
 {"entry_id": "term-074", "attempt": "购买力平价", "reference": "购买力平价", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-13T12:23:19.657251+00:00", "cli_version": "0.5.0"}
 {"entry_id": "term-066", "attempt": "朴素预期", "reference": "简单预期", "confidence": 3, "similarity": 0.3333, "timestamp": "2026-05-13T12:26:09.221563+00:00", "cli_version": "0.5.0", "diff_reason": "contextual", "notes": "naive的释义在不同情境下会发生变化。"}
 {"entry_id": "term-263", "attempt": "正态分布", "reference": "正态分布", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-13T12:26:34.516845+00:00", "cli_version": "0.5.0"}
->>>>>>> Stashed changes
 {"entry_id": "term-002", "attempt": "偏导数", "reference": "偏导数", "confidence": 5, "similarity": 1.0, "timestamp": "2026-05-13T15:22:36.752735+00:00", "cli_version": "0.5.0"}
 {"entry_id": "sent-035", "attempt": "因此，对{eq}`fin_mc_fr`进行迭代，表达式$\\psi_{t+m} = \\psi_t P^m$同样成立——其中$P^m$是$P$的$m$次幂。", "reference": "因此，迭代 {eq}`fin_mc_fr`，表达式 $\\psi_{t+m} = \\psi_t P^m$ 也是有效的——这里 $P^m$ 是 $P$ 的第 $m$ 次幂。", "confidence": 4, "similarity": 0.6875, "timestamp": "2026-05-13T15:31:31.311833+00:00", "cli_version": "0.5.0", "diff_reason": "contextual", "notes": "意思相同，中文表达细节不同。"}
 {"entry_id": "term-229", "attempt": "最优路径", "reference": "最优路径", "confidence": 4, "similarity": 1.0, "timestamp": "2026-05-13T16:22:58.638639+00:00", "cli_version": "0.5.0"}

--- a/src/qebench/commands/export.py
+++ b/src/qebench/commands/export.py
@@ -55,7 +55,11 @@ def _xp_leaderboard() -> list[dict]:
     for path in sorted(xp_dir.glob("*.json")):
         username = path.stem
         with open(path, encoding="utf-8") as f:
-            data = json.load(f)
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                console.print(f"[yellow]warning:[/] skipping malformed XP file {path.name}: {e}")
+                continue
         leaderboard.append({
             "username": username,
             "total_xp": data.get("total", 0),
@@ -75,11 +79,17 @@ def _activity_feed() -> list[dict]:
     for path in translations_dir.glob("*.jsonl"):
         username = path.stem
         with open(path, encoding="utf-8") as f:
-            for line in f:
+            for lineno, line in enumerate(f, 1):
                 line = line.strip()
                 if not line:
                     continue
-                record = json.loads(line)
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as e:
+                    console.print(
+                        f"[yellow]warning:[/] skipping malformed line {lineno} in {path.name}: {e}"
+                    )
+                    continue
                 record["username"] = username
                 entries.append(record)
 


### PR DESCRIPTION
Both the **CI** and **Deploy Docs** workflows have been red on `main`. Both failures trace to a single corrupted data file.

## Root cause

An unresolved `git stash` merge conflict was committed into `results/translations/Cindy6308.jsonl` — the file contained literal `<<<<<<< Updated upstream`, `=======`, and `>>>>>>> Stashed changes` marker lines. Both workflows read this file through `qebench export`, so the bad line crashes both:

| Workflow | Failing step | Cause |
| --- | --- | --- |
| CI | Run tests | `test_export.py` integration tests call `export()`, which `json.loads()` every line of `results/translations/*.jsonl` → `JSONDecodeError` on the marker line |
| Deploy Docs | Export dashboard data (`qebench export`) | Same crash → docs never build or deploy |

`qebench validate` only checks `data/` (the dataset), not `results/`, so the bad submission passed validation and merged.

## Fix

1. **Resolve the conflict** in `Cindy6308.jsonl` — removed the 3 marker lines, keeping all 16 valid entries from both sides (they do not overlap, so no data is lost).
2. **Harden the readers** in `export.py` — `_activity_feed()` and `_xp_leaderboard()` now skip-and-warn on malformed result files instead of crashing. This prevents a single bad community submission from taking down both CI and the docs deploy again.

## Verification (all four CI steps green locally)

- `qebench validate` → 411 entries
- `pytest tests/` → **262 passed** (was 2 failed / 260 passed)
- `ruff check src/ tests/` → clean
- `qebench export` → builds all 6 dashboard JSON files

## Follow-up (not in this PR)

Since `qebench validate` does not scan `results/`, consider adding a conflict-marker / JSONL check there or a pre-merge CI guard, so future bad submissions are caught before they merge rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)